### PR TITLE
chore: re-link existing tags page to navbar list

### DIFF
--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -3,6 +3,7 @@ const headerNavLinks = [
   { href: '/dashboard', title: 'Dashboard' },
   { href: '/projects', title: 'Projects' },
   { href: '/blog', title: 'Blog' },
+  { href: '/tags', title: 'Tags' },
   { href: '/about', title: 'About' },
 ]
 


### PR DESCRIPTION
# Summary
Somewhere along the way, the tags page was unlinked from the navbar. This branch fixes that unlink.